### PR TITLE
chore: pass repo token to CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,4 +14,5 @@ permissions:
 jobs:
   cla-check:
     uses: anyproto/open/.github/workflows/cla.yml@main
-    secrets: inherit
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- explicitly provide `GITHUB_TOKEN` when invoking the reusable CLA workflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c034775fcc8331b0767f1661420e60